### PR TITLE
Housekeeping

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -437,7 +437,7 @@ class Filter
      *
      * @return $this
      */
-    public function related()
+    public function relation():self
     {
         $this->withRules('nullable');
 

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -437,7 +437,7 @@ class Filter
      *
      * @return $this
      */
-    public function relation():self
+    public function relation(): self
     {
         $this->withRules('nullable');
 

--- a/src/FormationProvider.php
+++ b/src/FormationProvider.php
@@ -3,7 +3,6 @@
 namespace HeadlessLaravel\Formations;
 
 use HeadlessLaravel\Formations\Commands\FormationMakeCommand;
-use HeadlessLaravel\Formations\Http\Controllers\SeekerController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 

--- a/src/FormationProvider.php
+++ b/src/FormationProvider.php
@@ -54,8 +54,6 @@ class FormationProvider extends ServiceProvider
 
         Route::macro('seeker', function ($endpoint, $formations = []) {
             app(Manager::class)->seeker($endpoint, $formations);
-
-            Route::get($endpoint, [SeekerController::class, 'index']);
         });
     }
 }

--- a/src/FormationProvider.php
+++ b/src/FormationProvider.php
@@ -46,10 +46,8 @@ class FormationProvider extends ServiceProvider
 
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'formations');
 
-        Route::macro('formation', function ($resource, $formation) {
-            return app(Routes::class)
-                ->setResource($resource)
-                ->setFormation($formation);
+        Route::macro('formation', function ($formation) {
+            return app(Routes::class)->formation($formation);
         });
 
         Route::macro('seeker', function ($endpoint, $formations = []) {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -3,8 +3,10 @@
 namespace HeadlessLaravel\Formations;
 
 use HeadlessLaravel\Formations\Exceptions\UnregisteredFormation;
+use HeadlessLaravel\Formations\Http\Controllers\SeekerController;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 
 class Manager
@@ -120,6 +122,8 @@ class Manager
 
     public function seeker(string $endpoint, array $formations): self
     {
+        Route::get($endpoint, [SeekerController::class, 'index']);
+
         $this->seekers[$endpoint] = $formations;
 
         return $this;

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -2,7 +2,10 @@
 
 namespace HeadlessLaravel\Formations;
 
+use HeadlessLaravel\Formations\Http\Controllers\ImportController;
+use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Str;
 
 class Routes
@@ -12,6 +15,8 @@ class Routes
     public $resource;
 
     public $pivot = false;
+
+    public $import = false;
 
     protected $types = [];
 
@@ -32,7 +37,14 @@ class Routes
         $this->prefix = $this->router->getLastGroupPrefix();
     }
 
-    public function setResource($resource)
+    public function formation($formation)
+    {
+        $this->formation = $formation;
+
+        return $this;
+    }
+
+    public function resource($resource):self
     {
         $this->parent = Str::before($resource, '.');
         $this->resource = Str::after($resource, '.');
@@ -44,9 +56,16 @@ class Routes
         return $this;
     }
 
-    public function setFormation($formation)
+    public function pivot():self
     {
-        $this->formation = $formation;
+        $this->pivot = true;
+
+        return $this;
+    }
+
+    public function import():self
+    {
+        $this->import = true;
 
         return $this;
     }
@@ -86,6 +105,10 @@ class Routes
 
     public function makeName($name)
     {
+        if ($this->import) {
+            return "$this->resource.imports.$name";
+        }
+
         if ($this->parent) {
             return "$this->parent.$this->resource.$name";
         }
@@ -112,7 +135,9 @@ class Routes
     {
         $name = Str::camel($name);
 
-        if ($this->pivot) {
+        if ($this->import) {
+            return [ImportController::class, $name];
+        } elseif ($this->pivot) {
             return [app($this->formation)->pivotController, $name];
         } elseif ($this->parent) {
             return [app($this->formation)->nestedController, $name];
@@ -129,7 +154,8 @@ class Routes
             $this->router
                 ->addRoute($route['verb'], $route['endpoint'], $route['action'])
                 ->name($route['name'])
-                ->withTrashed($route['with-trashed']);
+                ->withTrashed($route['with-trashed'])
+                ->defaults('formation', $this->formation);
         }
 
         $this->manager->register([
@@ -146,7 +172,9 @@ class Routes
 
     public function endpoints(): array
     {
-        if ($this->pivot) {
+        if ($this->import) {
+            $endpoints = $this->importEndpoints();
+        } else if ($this->pivot) {
             $endpoints = $this->pivotEndpoints();
         } elseif ($this->parent) {
             $endpoints = $this->nestedEndpoints();
@@ -226,6 +254,13 @@ class Routes
         ];
     }
 
+    private function importEndpoints(): array
+    {
+        return [
+            ['type' => 'store', 'verb' => 'POST', 'endpoint' => "imports/$this->resource"],
+        ];
+    }
+
     public function makeRouteKey($key): string
     {
         return Str::of($key)->replace('-', '_')->singular();
@@ -239,13 +274,6 @@ class Routes
     public function resourceRouteKey(): string
     {
         return $this->makeRouteKey($this->resource);
-    }
-
-    public function pivot(): self
-    {
-        $this->pivot = true;
-
-        return $this;
     }
 
     /**

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -3,9 +3,7 @@
 namespace HeadlessLaravel\Formations;
 
 use HeadlessLaravel\Formations\Http\Controllers\ImportController;
-use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Str;
 
 class Routes
@@ -44,7 +42,7 @@ class Routes
         return $this;
     }
 
-    public function resource($resource):self
+    public function resource($resource): self
     {
         $this->parent = Str::before($resource, '.');
         $this->resource = Str::after($resource, '.');
@@ -56,14 +54,14 @@ class Routes
         return $this;
     }
 
-    public function pivot():self
+    public function pivot(): self
     {
         $this->pivot = true;
 
         return $this;
     }
 
-    public function import():self
+    public function import(): self
     {
         $this->import = true;
 
@@ -174,7 +172,7 @@ class Routes
     {
         if ($this->import) {
             $endpoints = $this->importEndpoints();
-        } else if ($this->pivot) {
+        } elseif ($this->pivot) {
             $endpoints = $this->pivotEndpoints();
         } elseif ($this->parent) {
             $endpoints = $this->nestedEndpoints();

--- a/tests/Fixtures/PostFormation.php
+++ b/tests/Fixtures/PostFormation.php
@@ -2,6 +2,7 @@
 
 namespace HeadlessLaravel\Formations\Tests\Fixtures;
 
+use HeadlessLaravel\Formations\Field;
 use HeadlessLaravel\Formations\Filter;
 use HeadlessLaravel\Formations\Formation;
 use HeadlessLaravel\Formations\Tests\Fixtures\Models\Post;
@@ -75,14 +76,14 @@ class PostFormation extends Formation
             Filter::make('author_id')->multiple(),
             Filter::make('like')->exists()->auth(),
             Filter::make('length')->range(),
-            Filter::make('author')->related(),
-            Filter::make('writer', 'author')->related()->multiple(),
+            Filter::make('author')->relation(),
+            Filter::make('writer', 'author')->relation()->multiple(),
             Filter::make('active')->boolean(),
             Filter::make('toggle', 'active')->toggle(),
             Filter::make('comments')->exists(),
             Filter::make('comments')->count(),
             Filter::make('comments')->countRange(),
-            Filter::make('tagged', 'tags')->related()->multiple(),
+            Filter::make('tagged', 'tags')->relation()->multiple(),
             Filter::make('tags')->exists(),
             Filter::make('tags')->count(),
             Filter::make('tags')->countRange(),

--- a/tests/Fixtures/PostFormation.php
+++ b/tests/Fixtures/PostFormation.php
@@ -2,7 +2,6 @@
 
 namespace HeadlessLaravel\Formations\Tests\Fixtures;
 
-use HeadlessLaravel\Formations\Field;
 use HeadlessLaravel\Formations\Filter;
 use HeadlessLaravel\Formations\Formation;
 use HeadlessLaravel\Formations\Tests\Fixtures\Models\Post;

--- a/tests/Fixtures/routes.php
+++ b/tests/Fixtures/routes.php
@@ -12,7 +12,14 @@ Route::seeker('search', [
     AuthorFormation::class,
 ]);
 
-Route::formation('posts', PostFormation::class);
-Route::formation('authors', AuthorFormation::class);
-Route::formation('authors.posts', PostFormation::class);
-Route::formation('posts.tags', TagFormation::class)->pivot();
+Route::formation(PostFormation::class)->resource('posts');
+Route::formation(AuthorFormation::class)->resource('authors');
+Route::formation(PostFormation::class)->resource('authors.posts');
+
+Route::formation(TagFormation::class)
+    ->resource('posts.tags')
+    ->pivot();
+
+Route::formation(PostFormation::class)
+    ->resource('posts')
+    ->import();

--- a/tests/NestedControllerTest.php
+++ b/tests/NestedControllerTest.php
@@ -26,7 +26,7 @@ class NestedControllerTest extends TestCase
     {
         $this->expectException(UnregisteredFormation::class);
 
-        Route::formation('users.posts', PostFormation::class);
+        Route::formation(PostFormation::class)->resource('users.posts');
     }
 
     public function test_indexing_a_nested_resource()

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -16,10 +16,10 @@ class RoutesTest extends TestCase
         // preloaded from routes.php
         $routesFilesRoutes = count(Route::getRoutes());
 
-        Route::formation('articles', PostFormation::class)->only('index');
-        Route::formation('articles.tags', TagFormation::class)->only(['index']);
-        Route::formation('articles.tags', TagFormation::class)->pivot()->only(['sync']);
-        Route::formation('authors.articles', PostFormation::class)->only(['index']);
+        Route::formation(PostFormation::class)->resource('articles')->only('index');
+        Route::formation(TagFormation::class)->resource('articles.tags')->only(['index']);
+        Route::formation(TagFormation::class)->resource('articles.tags')->pivot()->only(['sync']);
+        Route::formation(PostFormation::class)->resource('authors.articles')->only(['index']);
 
         $routes = Route::getRoutes();
         $routes->refreshNameLookups();
@@ -36,9 +36,9 @@ class RoutesTest extends TestCase
         // preloaded from routes.php
         $routesFilesRoutes = count(Route::getRoutes());
 
-        $a = Route::formation('articles', PostFormation::class)->except('index')->create();
-        $b = Route::formation('articles.tags', TagFormation::class)->except(['index'])->create();
-        $c = Route::formation('articles.tags', TagFormation::class)->pivot()->except(['sync', 'index', 'show'])->create();
+        $a = Route::formation(PostFormation::class)->resource('articles')->except('index')->create();
+        $b = Route::formation(TagFormation::class)->resource('articles.tags')->except(['index'])->create();
+        $c = Route::formation(TagFormation::class)->resource('articles.tags')->pivot()->except(['sync', 'index', 'show'])->create();
 
         $routes = Route::getRoutes();
         $routes->refreshNameLookups();


### PR DESCRIPTION
This PR adjusts the route formation approach [seen here](https://github.com/headlesslaravel/formations/wiki/Routes)

```php
Route::formation('articles', ArticleFormation::class)
```
```php
Route::formation(ArticleFormation::class)->resource('articles')
```

And changes filter related to relation

```php
Filter::make('author')->related()
```
```php
Filter::make('author')->relation()
```

And some other small refactors and cleanup